### PR TITLE
Add basic H2 support

### DIFF
--- a/base/src/main/java/io/github/rieske/dbtest/extension/TestDatabase.java
+++ b/base/src/main/java/io/github/rieske/dbtest/extension/TestDatabase.java
@@ -20,7 +20,7 @@ class TestDatabase {
             case DATABASE_PER_EXECUTION:
                 return perExecution;
             default:
-                throw new IllegalStateException("No database state strategy exists for " + this + " mode");
+                throw new IllegalStateException("No database state strategy exists for " + mode + " mode");
         }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-org.gradle.unsafe.configuration-cache=true
+org.gradle.configuration-cache=true
 group=io.github.rieske.dbtest
-version=0.0.3
+version=0.0.4

--- a/h2/build.gradle
+++ b/h2/build.gradle
@@ -1,0 +1,22 @@
+plugins {
+    id("io.github.rieske.dbtest.published-library")
+}
+
+description = "Fast tests against in-memory H2 database."
+
+dependencies {
+    api(project(":base"))
+
+    implementation("com.h2database:h2:2.1.214")
+}
+
+testing {
+    suites {
+        test {
+            dependencies {
+                implementation("org.apache.logging.log4j:log4j-slf4j-impl:2.20.0")
+                implementation(project.dependencies.testFixtures(project(":base")))
+            }
+        }
+    }
+}

--- a/h2/src/main/java/io/github/rieske/dbtest/extension/H2FastTestExtension.java
+++ b/h2/src/main/java/io/github/rieske/dbtest/extension/H2FastTestExtension.java
@@ -1,0 +1,17 @@
+package io.github.rieske.dbtest.extension;
+
+/**
+ * JUnit5 extension that enables you to write tests against an in-memory H2 database.
+ */
+public abstract class H2FastTestExtension extends H2TestExtension {
+
+    /**
+     * Create an H2 database extension.
+     *
+     * @param h2mode            H2 database mode, see <a href="https://www.h2database.com/html/features.html#feature_list">SQL support</a>.
+     * @param dataRetentionMode the data retention mode to use for this extension.
+     */
+    public H2FastTestExtension(H2Mode h2mode, DatabaseTestExtension.Mode dataRetentionMode) {
+        super(h2mode, dataRetentionMode, true);
+    }
+}

--- a/h2/src/main/java/io/github/rieske/dbtest/extension/H2Mode.java
+++ b/h2/src/main/java/io/github/rieske/dbtest/extension/H2Mode.java
@@ -1,0 +1,17 @@
+package io.github.rieske.dbtest.extension;
+
+/**
+ * H2 compatibility mode
+ */
+public enum H2Mode {
+    /**
+     * Emulate PostgreSQL
+     */
+    POSTGRESQL("PostgreSQL");
+
+    final String connectionStringValue;
+
+    H2Mode(String connectionStringValue) {
+        this.connectionStringValue = connectionStringValue;
+    }
+}

--- a/h2/src/main/java/io/github/rieske/dbtest/extension/H2TestDatabase.java
+++ b/h2/src/main/java/io/github/rieske/dbtest/extension/H2TestDatabase.java
@@ -1,0 +1,69 @@
+package io.github.rieske.dbtest.extension;
+
+import org.h2.jdbcx.JdbcDataSource;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
+
+class H2TestDatabase extends DatabaseEngine {
+    private record Database(String name, DataSource dataSource, Connection connection) {}
+
+    private final DataSource templateDataSource;
+    private final Map<String, Database> databases = new ConcurrentHashMap<>();
+    private Consumer<DataSource> migrator;
+
+
+    H2TestDatabase() {
+        this.templateDataSource = dataSourceForDatabase(getTemplateDatabaseName());
+    }
+
+    @Override
+    void cloneTemplateDatabaseTo(String targetDatabaseName) {
+        migrator.accept(dataSourceForDatabase(targetDatabaseName));
+    }
+
+    @Override
+    DataSource dataSourceForDatabase(String databaseName) {
+        if (!databases.containsKey(databaseName)) {
+            JdbcDataSource dataSource = new JdbcDataSource();
+            dataSource.setUrl("jdbc:h2:mem:" + databaseName + ";MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DB_CLOSE_DELAY=1");
+            try {
+                databases.put(databaseName, new Database(databaseName, dataSource, dataSource.getConnection()));
+            } catch (SQLException e) {
+                throw new RuntimeException("Could not acquire a connection", e);
+            }
+        }
+        return databases.get(databaseName).dataSource();
+    }
+
+    @Override
+    String getTemplateDatabaseName() {
+        return "template";
+    }
+
+    @Override
+    DataSource getPrivilegedDataSource() {
+        return templateDataSource;
+    }
+
+    @Override
+    void migrateTemplateDatabase(Consumer<DataSource> migrator, DataSource templateDataSource) {
+        this.migrator = migrator;
+    }
+
+    @Override
+    void dropDatabase(String databaseName) {
+        Database database = databases.get(databaseName);
+        if (database != null) {
+            try {
+                database.connection().close();
+            } catch (SQLException e) {
+                throw new RuntimeException("Could not close a connection", e);
+            }
+        }
+    }
+}

--- a/h2/src/main/java/io/github/rieske/dbtest/extension/H2TestDatabaseManager.java
+++ b/h2/src/main/java/io/github/rieske/dbtest/extension/H2TestDatabaseManager.java
@@ -1,0 +1,13 @@
+package io.github.rieske.dbtest.extension;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+class H2TestDatabaseManager {
+    private static final Map<H2Mode, TestDatabase> DATABASES = new ConcurrentHashMap<>();
+
+    static TestDatabase getDatabase(H2Mode dialect) {
+        // TODO: pass dialect on to H2
+        return DATABASES.computeIfAbsent(dialect, d -> new TestDatabase(new H2TestDatabase()));
+    }
+}

--- a/h2/src/main/java/io/github/rieske/dbtest/extension/H2TestExtension.java
+++ b/h2/src/main/java/io/github/rieske/dbtest/extension/H2TestExtension.java
@@ -1,0 +1,7 @@
+package io.github.rieske.dbtest.extension;
+
+abstract class H2TestExtension extends DatabaseTestExtension {
+    H2TestExtension(H2Mode dialect, Mode mode, boolean migrateOnce) {
+        super(H2TestDatabaseManager.getDatabase(dialect), mode, migrateOnce);
+    }
+}

--- a/h2/src/test/java/io/github/rieske/dbtest/H2PerformanceTests.java
+++ b/h2/src/test/java/io/github/rieske/dbtest/H2PerformanceTests.java
@@ -1,0 +1,27 @@
+package io.github.rieske.dbtest;
+
+import io.github.rieske.dbtest.extension.DatabaseTestExtension;
+import org.junit.jupiter.api.Nested;
+
+class H2PerformanceTests implements H2Test {
+    @Nested
+    class H2DatabasePerTestMethodPerformanceTest extends PerformanceTests {
+        H2DatabasePerTestMethodPerformanceTest() {
+            super(slowExtension(DatabaseTestExtension.Mode.DATABASE_PER_TEST_METHOD), fastExtension(DatabaseTestExtension.Mode.DATABASE_PER_TEST_METHOD));
+        }
+    }
+
+    @Nested
+    class H2DatabasePerTestClassPerformanceTest extends PerformanceTests {
+        H2DatabasePerTestClassPerformanceTest() {
+            super(slowExtension(DatabaseTestExtension.Mode.DATABASE_PER_TEST_CLASS), fastExtension(DatabaseTestExtension.Mode.DATABASE_PER_TEST_CLASS));
+        }
+    }
+
+    @Nested
+    class H2DatabasePerExecutionPerformanceTest extends PerformanceTests {
+        H2DatabasePerExecutionPerformanceTest() {
+            super(slowExtension(DatabaseTestExtension.Mode.DATABASE_PER_EXECUTION), fastExtension(DatabaseTestExtension.Mode.DATABASE_PER_EXECUTION));
+        }
+    }
+}

--- a/h2/src/test/java/io/github/rieske/dbtest/H2StateGuaranteeTests.java
+++ b/h2/src/test/java/io/github/rieske/dbtest/H2StateGuaranteeTests.java
@@ -1,0 +1,27 @@
+package io.github.rieske.dbtest;
+
+import io.github.rieske.dbtest.extension.DatabaseTestExtension;
+import org.junit.jupiter.api.Nested;
+
+class H2StateGuaranteeTests implements H2Test {
+    @Nested
+    class H2DatabasePerTestMethodTest extends DatabasePerTestMethodTest {
+        H2DatabasePerTestMethodTest() {
+            super(slowExtension(DatabaseTestExtension.Mode.DATABASE_PER_TEST_METHOD), fastExtension(DatabaseTestExtension.Mode.DATABASE_PER_TEST_METHOD));
+        }
+    }
+
+    @Nested
+    class H2DatabasePerTestClassTest extends DatabasePerTestClassTest {
+        H2DatabasePerTestClassTest() {
+            super(slowExtension(DatabaseTestExtension.Mode.DATABASE_PER_TEST_CLASS), fastExtension(DatabaseTestExtension.Mode.DATABASE_PER_TEST_CLASS));
+        }
+    }
+
+    @Nested
+    class H2DatabasePerExecutionTest extends DatabasePerExecutionTest {
+        H2DatabasePerExecutionTest() {
+            super(slowExtension(DatabaseTestExtension.Mode.DATABASE_PER_EXECUTION), fastExtension(DatabaseTestExtension.Mode.DATABASE_PER_EXECUTION));
+        }
+    }
+}

--- a/h2/src/test/java/io/github/rieske/dbtest/H2Test.java
+++ b/h2/src/test/java/io/github/rieske/dbtest/H2Test.java
@@ -1,0 +1,14 @@
+package io.github.rieske.dbtest;
+
+import io.github.rieske.dbtest.extension.DatabaseTestExtension;
+import io.github.rieske.dbtest.extension.FlywayH2FastTestExtension;
+
+public interface H2Test {
+    default DatabaseTestExtension slowExtension(DatabaseTestExtension.Mode mode) {
+        return new FlywayH2FastTestExtension(mode);
+    }
+
+    default DatabaseTestExtension fastExtension(DatabaseTestExtension.Mode mode) {
+        return new FlywayH2FastTestExtension(mode);
+    }
+}

--- a/h2/src/test/java/io/github/rieske/dbtest/extension/FlywayH2FastTestExtension.java
+++ b/h2/src/test/java/io/github/rieske/dbtest/extension/FlywayH2FastTestExtension.java
@@ -1,0 +1,16 @@
+package io.github.rieske.dbtest.extension;
+
+import io.github.rieske.dbtest.FlywayMigrator;
+
+import javax.sql.DataSource;
+
+public class FlywayH2FastTestExtension extends H2FastTestExtension {
+    public FlywayH2FastTestExtension(DatabaseTestExtension.Mode mode) {
+        super(H2Mode.POSTGRESQL, mode);
+    }
+
+    @Override
+    protected void migrateDatabase(DataSource dataSource) {
+        FlywayMigrator.migrateDatabase(dataSource);
+    }
+}

--- a/postgresql/src/main/java/io/github/rieske/dbtest/extension/PostgreSQLTestDatabase.java
+++ b/postgresql/src/main/java/io/github/rieske/dbtest/extension/PostgreSQLTestDatabase.java
@@ -14,6 +14,11 @@ class PostgreSQLTestDatabase extends DatabaseEngine {
     @SuppressWarnings("resource")
     PostgreSQLTestDatabase(String version) {
         this.container = new PostgreSQLContainer<>("postgres:" + version).withReuse(true);
+        this.container.setCommand(
+                "postgres",
+                "-c", "fsync=off",
+                "-c", "full_page_writes=off"
+        );
         this.container.withTmpFs(Map.of("/var/lib/postgresql/data", "rw"));
         this.container.start();
         this.jdbcPrefix = "jdbc:postgresql://" + container.getHost() + ":" + container.getMappedPort(5432) + "/";

--- a/settings.gradle
+++ b/settings.gradle
@@ -11,3 +11,4 @@ rootProject.name = "dbtest"
 include(":base")
 include(":mysql")
 include(":postgresql")
+include(":h2")


### PR DESCRIPTION
Limitations:
- Only PostgreSQL compatibility for now.
- Does not reuse migrated databases. Each test execution in per-method mode will apply all migrations to a fresh database.