### PR TITLE
Raise baseline to Java 17 (unblock major dependency upgrades)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v5
         with:
-          java-version: 11
+          java-version: 17
           distribution: temurin
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v5
         with:
-          java-version: 11
+          java-version: 17
           distribution: temurin
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
@@ -49,7 +49,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v5
         with:
-          java-version: 11
+          java-version: 17
           distribution: temurin
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
@@ -67,7 +67,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v5
         with:
-          java-version: 11
+          java-version: 17
           distribution: temurin
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v5
         with:
-          java-version: 11
+          java-version: 17
           distribution: temurin
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6

--- a/base/src/testFixtures/java/io/github/rieske/dbtest/DatabasePerExecutionTest.java
+++ b/base/src/testFixtures/java/io/github/rieske/dbtest/DatabasePerExecutionTest.java
@@ -15,6 +15,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+// Slow/Fast suites share DATABASE_PER_EXECUTION state and a static counter; keep them
+// single-threaded so parallel JUnit does not race the shared record count.
+@Execution(ExecutionMode.SAME_THREAD)
 public abstract class DatabasePerExecutionTest {
     private final DatabaseTestExtension slowExtension;
     private final DatabaseTestExtension fastExtension;

--- a/gradle/build-logic/src/main/groovy/io.github.rieske.dbtest.java-library.gradle
+++ b/gradle/build-logic/src/main/groovy/io.github.rieske.dbtest.java-library.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_11
+    sourceCompatibility = JavaVersion.VERSION_17
     withSourcesJar()
     withJavadocJar()
 }


### PR DESCRIPTION
## Summary

Path B foundation for merging the open Renovate major upgrades that currently fail on Java 11:

- **CI / publish**: run on JDK 17 (`build.yml`, `publish.yml`)
- **Library bytecode**: `sourceCompatibility` 11 → 17
- **Flaky H2 tests**: force `DatabasePerExecutionTest` to `SAME_THREAD` so Slow/Fast suites cannot race the shared static record counter (this is what failed on the logback PR)

This is intentionally a small baseline PR so it can be refined before the dependency PRs are rebased onto it.

## Unblocks

| PR | Why it needed Java 17 |
|----|------------------------|
| #205 Gradle 9 | Gradle 9 must *run* on JVM 17+ |
| #215 JUnit 6 | `junit-jupiter-api` 6.x requires Java 17 (and is an `api` dependency) |
| #142 Flyway 12 | Flyway 10+ is Java 17 bytecode; will also need `flyway-database-*` modules after rebase |
| #251 logback 1.5.38 | Only h2 flake; should be green after this + rebase |

## After this merges

1. Rebase each open Renovate PR onto `main`
2. On #142, add Flyway 10+ DB support modules (`flyway-database-postgresql`, and H2 if required)
3. Wait for green CI, merge one by one, re-sync to `main` after each merge

## Test plan

- [x] `./gradlew build -x :postgresql:test -x :mysql:test` (includes `:h2:test`) locally
- [ ] GitHub Actions branch workflow green (build + postgres/mysql matrix + h2)