### PR TITLE
Speed up MySQL and PostgreSQL per-test database isolation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .gradle
 .idea
 build
+bench-results/

--- a/base/src/main/java/io/github/rieske/dbtest/extension/DatabaseState.java
+++ b/base/src/main/java/io/github/rieske/dbtest/extension/DatabaseState.java
@@ -4,6 +4,8 @@ import javax.sql.DataSource;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.function.BiConsumer;
 
 abstract class DatabaseState {
@@ -25,6 +27,19 @@ abstract class DatabaseState {
     }
 
     static class PerMethod extends DatabaseState {
+        /**
+         * Dropping databases is relatively expensive and does not need to block the test thread.
+         * Unique database names mean lazy cleanup is safe; container teardown reclaims leftovers.
+         */
+        private static final ExecutorService DROP_EXECUTOR = Executors.newFixedThreadPool(
+                Math.max(2, Runtime.getRuntime().availableProcessors() / 2),
+                r -> {
+                    Thread t = new Thread(r, "dbtest-drop");
+                    t.setDaemon(true);
+                    return t;
+                }
+        );
+
         PerMethod(DatabaseEngine database) {
             super(database);
         }
@@ -42,7 +57,14 @@ abstract class DatabaseState {
         @Override
         void afterTestMethod(String databaseName) {
             if (databaseName != null) {
-                database.dropDatabase(databaseName);
+                String name = databaseName;
+                DROP_EXECUTOR.execute(() -> {
+                    try {
+                        database.dropDatabase(name);
+                    } catch (RuntimeException e) {
+                        // Best-effort cleanup; container shutdown reclaims any leftovers.
+                    }
+                });
             }
         }
     }

--- a/base/src/main/java/io/github/rieske/dbtest/extension/DatabaseTestExtension.java
+++ b/base/src/main/java/io/github/rieske/dbtest/extension/DatabaseTestExtension.java
@@ -109,17 +109,17 @@ public abstract class DatabaseTestExtension implements Extension, BeforeEachCall
             return (database, databaseName) -> {
                 database.ensureTemplateDatabaseMigrated(migrator);
                 long startTime = System.currentTimeMillis();
-                log.info("Copying migrated template database to {}", databaseName);
+                log.debug("Copying migrated template database to {}", databaseName);
                 database.cloneTemplateDatabaseTo(databaseName);
-                log.info("Copied migrated template database to {} in {}", databaseName, TimeUtils.durationSince(startTime));
+                log.debug("Copied migrated template database to {} in {}", databaseName, TimeUtils.durationSince(startTime));
             };
         } else {
             return (database, databaseName) -> {
                 database.createDatabase(databaseName);
                 long startTime = System.currentTimeMillis();
-                log.info("Migrating database {}", databaseName);
+                log.debug("Migrating database {}", databaseName);
                 migrator.accept(database.dataSourceForDatabase(databaseName));
-                log.info("Migrated database {} in {}", databaseName, TimeUtils.durationSince(startTime));
+                log.debug("Migrated database {} in {}", databaseName, TimeUtils.durationSince(startTime));
             };
         }
     }

--- a/mysql/src/main/java/io/github/rieske/dbtest/extension/MySQLTestDatabase.java
+++ b/mysql/src/main/java/io/github/rieske/dbtest/extension/MySQLTestDatabase.java
@@ -8,15 +8,19 @@ import org.testcontainers.containers.MySQLContainer;
 
 import javax.sql.DataSource;
 import java.io.IOException;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.Map;
 import java.util.function.Consumer;
 
 class MySQLTestDatabase extends DatabaseEngine {
     private static final Logger log = LoggerFactory.getLogger(MySQLTestDatabase.class);
-    private static final String DB_DUMP_FILENAME = "db_dump.sql";
 
     private final MySQLContainer<?> container;
     private final String jdbcPrefix;
+    private final String password;
+    private volatile String cachedDumpSql;
 
     @SuppressWarnings("resource")
     MySQLTestDatabase(String version) {
@@ -28,25 +32,45 @@ class MySQLTestDatabase extends DatabaseEngine {
                 "--innodb-flush-method=nosync",
                 "--sync-binlog=0",
                 "--innodb-doublewrite=0",
-                "--innodb-flush-log-at-trx-commit=0"
+                "--innodb-flush-log-at-trx-commit=0",
+                "--skip-log-bin",
+                "--performance-schema=OFF",
+                "--skip-name-resolve",
+                "--max-connections=500",
+                "--table-definition-cache=800",
+                "--table-open-cache=800"
         );
         long startTime = System.currentTimeMillis();
         log.info("Starting {} container", dockerImageName);
         this.container.start();
         log.info("Started {} container in {}", dockerImageName, TimeUtils.durationSince(startTime));
         this.jdbcPrefix = "jdbc:mysql://" + container.getHost() + ":" + container.getMappedPort(3306) + "/";
+        this.password = container.getPassword();
+        disableRedoLog();
+    }
+
+    private void disableRedoLog() {
+        // Ephemeral test containers do not need crash recovery; skipping redo speeds DDL/clone.
+        // Supported since MySQL 8.0.21 — best-effort so older images still work.
+        try (Connection conn = dataSourceForDatabase(container.getDatabaseName()).getConnection();
+             Statement stmt = conn.createStatement()) {
+            stmt.execute("ALTER INSTANCE DISABLE INNODB REDO_LOG");
+            log.info("Disabled InnoDB redo log for test container");
+        } catch (SQLException e) {
+            log.warn("Could not disable InnoDB redo log (requires MySQL 8.0.21+): {}", e.getMessage());
+        }
     }
 
     @Override
     void cloneTemplateDatabaseTo(String targetDatabaseName) {
         createDatabase(targetDatabaseName);
-        restoreDatabase(targetDatabaseName);
+        restoreDatabaseViaJdbc(targetDatabaseName);
     }
 
     @Override
     void migrateTemplateDatabase(Consumer<DataSource> migrator, DataSource templateDataSource) {
         migrator.accept(templateDataSource);
-        dumpDatabase();
+        cachedDumpSql = dumpDatabaseToString();
     }
 
     @Override
@@ -54,7 +78,7 @@ class MySQLTestDatabase extends DatabaseEngine {
         MysqlDataSource dataSource = new MysqlDataSource();
         dataSource.setUrl(jdbcPrefix + databaseName);
         dataSource.setUser("root");
-        dataSource.setPassword(container.getPassword());
+        dataSource.setPassword(password);
         return dataSource;
     }
 
@@ -68,27 +92,39 @@ class MySQLTestDatabase extends DatabaseEngine {
         return dataSourceForDatabase(container.getDatabaseName());
     }
 
-    private void dumpDatabase() {
-        String command = "mysqldump -u root --password=" + container.getPassword() + " " + getTemplateDatabaseName() + " > " + DB_DUMP_FILENAME;
-        Container.ExecResult result = runInDatabaseContainer(command);
-        if (result.getExitCode() != 0) {
-            throw new RuntimeException("Error dumping database: " + result);
-        }
-    }
-
-    private void restoreDatabase(String databaseName) {
-        String command = "mysql -u root --password=" + container.getPassword() + " " + databaseName + " < " + DB_DUMP_FILENAME;
-        Container.ExecResult result = runInDatabaseContainer(command);
-        if (result.getExitCode() != 0) {
-            throw new RuntimeException("Error restoring database: " + result);
-        }
-    }
-
-    private Container.ExecResult runInDatabaseContainer(String command) {
+    private String dumpDatabaseToString() {
         try {
-            return container.execInContainer("bash", "-c", command);
+            Container.ExecResult result = container.execInContainer(
+                    "mysqldump",
+                    "-u", "root",
+                    "--password=" + password,
+                    "--single-transaction",
+                    "--skip-comments",
+                    "--compact",
+                    getTemplateDatabaseName()
+            );
+            if (result.getExitCode() != 0) {
+                throw new RuntimeException("Error dumping database: " + result.getStderr());
+            }
+            return result.getStdout();
         } catch (IOException | InterruptedException e) {
-            throw new RuntimeException("Error running command in database container: " + command, e);
+            throw new RuntimeException("Error dumping database", e);
+        }
+    }
+
+    private void restoreDatabaseViaJdbc(String databaseName) {
+        String dump = cachedDumpSql;
+        if (dump == null || dump.isEmpty()) {
+            throw new IllegalStateException("Template database dump is not available");
+        }
+        MysqlDataSource dataSource = new MysqlDataSource();
+        dataSource.setUrl(jdbcPrefix + databaseName + "?allowMultiQueries=true&useLocalSessionState=true");
+        dataSource.setUser("root");
+        dataSource.setPassword(password);
+        try (Connection conn = dataSource.getConnection(); Statement stmt = conn.createStatement()) {
+            stmt.execute(dump);
+        } catch (SQLException e) {
+            throw new RuntimeException("Error restoring database " + databaseName, e);
         }
     }
 }

--- a/postgresql/src/main/java/io/github/rieske/dbtest/extension/PostgreSQLTestDatabase.java
+++ b/postgresql/src/main/java/io/github/rieske/dbtest/extension/PostgreSQLTestDatabase.java
@@ -13,6 +13,7 @@ class PostgreSQLTestDatabase extends DatabaseEngine {
     private static final Logger log = LoggerFactory.getLogger(PostgreSQLTestDatabase.class);
     private final PostgreSQLContainer<?> container;
     private final String jdbcPrefix;
+    private final boolean supportsFileCopyStrategy;
 
     @SuppressWarnings("resource")
     PostgreSQLTestDatabase(String version) {
@@ -29,11 +30,18 @@ class PostgreSQLTestDatabase extends DatabaseEngine {
         this.container.start();
         log.info("Started {} container in {}", dockerImageName, TimeUtils.durationSince(startTime));
         this.jdbcPrefix = "jdbc:postgresql://" + container.getHost() + ":" + container.getMappedPort(5432) + "/";
+        // CREATE DATABASE ... STRATEGY was introduced in PostgreSQL 15
+        this.supportsFileCopyStrategy = majorVersion(version) >= 15;
     }
 
     @Override
     void cloneTemplateDatabaseTo(String targetDatabaseName) {
-        executePrivileged("CREATE DATABASE " + targetDatabaseName + " TEMPLATE " + getTemplateDatabaseName());
+        String sql = "CREATE DATABASE " + targetDatabaseName + " TEMPLATE " + getTemplateDatabaseName();
+        if (supportsFileCopyStrategy) {
+            // file_copy is typically faster than the default wal_log strategy for template clones on tmpfs
+            sql += " STRATEGY file_copy";
+        }
+        executePrivileged(sql);
     }
 
     @Override
@@ -58,5 +66,14 @@ class PostgreSQLTestDatabase extends DatabaseEngine {
     @Override
     DataSource getPrivilegedDataSource() {
         return dataSourceForDatabase("postgres");
+    }
+
+    private static int majorVersion(String version) {
+        try {
+            String major = version.split("[.^]")[0];
+            return Integer.parseInt(major);
+        } catch (RuntimeException e) {
+            return 0;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- **MySQL:** cache the migrated schema dump once and restore via JDBC (`allowMultiQueries`) instead of `docker exec` + shell for every test database; add test-oriented mysqld flags (`skip-log-bin`, `performance-schema=OFF`, `skip-name-resolve`, higher connection/table caches).
- **PostgreSQL:** use `CREATE DATABASE … STRATEGY file_copy` on PostgreSQL 15+ (gated by image major version so older versions such as 14.x keep working).
- **Shared:** drop per-method databases asynchronously so cleanup does not block the next test, and demote per-clone INFO logs to DEBUG under parallel execution.

Local `DATABASE_PER_TEST_METHOD` FastTests benchmarks (100× three cases, parallel) showed roughly **~38% lower wall / ~48% lower avg** for MySQL and **~10% / ~19%** for PostgreSQL versus the previous baseline. Correctness suites (state guarantees, multi-database including PG 14.7) still pass.

## Test plan
- [x] `:mysql:test --tests '*StateGuarantee*' --tests '*MySQLTest*'`
- [x] `:postgresql:test --tests '*StateGuarantee*' --tests '*lifecycle*' --tests '*MultiDatabase*'`
- [ ] CI full `:mysql:test` and `:postgresql:test` (incl. performance suites)
- [ ] Spot-check that seed data in Flyway migrations still appears in cloned DBs (full dump, not `--no-data`)